### PR TITLE
Fix sorted object list

### DIFF
--- a/lib/fakes3/sorted_object_list.rb
+++ b/lib/fakes3/sorted_object_list.rb
@@ -35,8 +35,9 @@ module FakeS3
     def add(s3_object)
       return if !s3_object
 
-      @object_map[s3_object.name] = s3_object
-      @sorted_set << s3_object
+      if @sorted_set.add(s3_object)
+        @object_map[s3_object.name] = s3_object
+      end
     end
 
     def remove(s3_object)


### PR DESCRIPTION
object_map and sorted_set end up containing different S3Objects if you put to the same key twice.  
The hash assignment takes the new object, and the sorted set rejects the item because it's already got one by that name.
Then if you make the item move to glacier, it'll look like it's there if you get the one object, but not if you ask for a list.  